### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,21 +66,22 @@ Built for modern PowerShell, including enumerators, classes, and advanced langua
 ## Workflow Overview
 
 ```mermaid
-
 graph TD
-  A[🚀 Start A New Pwsh Module Project] --> B[💻 Code your functions]
+  A[🚀 Start a New PowerShell Module] --> B[💻 Code Your Functions]
   B --> C[🔍 Test Locally]
-  C --> D[📦 Commit Changes & Open a PR]
+  C --> D[💾 Commit & Open a PR]
+  D --> E
   subgraph "CI ⚙️"
-  D --> E[🧪 Automated Pester and PSInvoke Tests]
-  E --> F[👀 Review and Merge]
+    E[🧪 Pester Tests & PSScriptAnalyzer]
   end
+  E -->|Fail| B
+  E -->|Pass| F[👀 Review & Merge]
+  F --> G
   subgraph "CD 🚚"
-  F --> G[🏷️ Build & Release Version]
-  G --> H[⏬ Deploy & Use]
+    G[🏷️ Build & Release Version]
+    G --> H[📤 Deploy & Publish]
   end
   H --> B
-
 ```
 
 ## Design Goals

--- a/source/functions/Get-MFGitLatestVersion.Tests.ps1
+++ b/source/functions/Get-MFGitLatestVersion.Tests.ps1
@@ -85,3 +85,101 @@ Describe 'Get-MFGitLatestVersion' {
         remove-alias git
     }
 }
+
+Describe 'Get-MFGitLatestVersion - Mixed semver and non-semver tags' {
+    BeforeAll{
+        function invoke-GitCommand{
+            [CmdletBinding()]
+            PARAM(
+                [Parameter(Position = 0)][Alias("p0")][string]$Param0,
+                [Parameter(Position = 1)][Alias("p1")][string]$Param1,
+                [Parameter(Position = 2)][Alias("p2")][string]$Param2,
+                [Parameter(Position = 3)][Alias("p3")][string]$Param3,
+                [Parameter(Position = 4)][Alias("p4")][string]$Param4,
+                [Parameter(Position = 5)][Alias("p5")][string]$Param5,
+                [Parameter(Position = 6)][Alias("p6")][string]$Param6
+            )
+            begin{
+                $commandLine = "$Param0 $Param1 $Param2 $Param3 $Param4 $Param5 $Param6".trim()
+                $tags = @(
+                    'latest'
+                    'release-candidate'
+                    'v1.1.0-prev004'
+                    'not-a-version'
+                    'v1.0.0'
+                    'v1.1.0'
+                    'something'
+                    'v1.2.3'
+                )
+            }
+            process{
+                switch -Wildcard ($commandLine) {
+                    '--version' { return 'git version 2.30.0.mock' }
+                    'tag *' {$global:LASTEXITCODE = 0; return $tags}
+                    default { throw "Unexpected git command: $commandLine" }
+                }
+            }
+        }
+
+        Set-Alias -name 'git' -Value invoke-GitCommand
+
+        $latestVer = Get-MFGitLatestVersion
+    }
+
+    It 'Should ignore non-semver tags and return the highest valid version' {
+        $latestVer.GetType().name | should -be 'SemanticVersion'
+        $latestVer.ToString() | should -be '1.2.3'
+        $latestVer.prereleaselabel | should -BeNullOrEmpty
+    }
+
+    AfterAll{
+        remove-alias git
+    }
+}
+
+Describe 'Get-MFGitLatestVersion - Only non-semver tags' {
+    BeforeAll{
+        function invoke-GitCommand{
+            [CmdletBinding()]
+            PARAM(
+                [Parameter(Position = 0)][Alias("p0")][string]$Param0,
+                [Parameter(Position = 1)][Alias("p1")][string]$Param1,
+                [Parameter(Position = 2)][Alias("p2")][string]$Param2,
+                [Parameter(Position = 3)][Alias("p3")][string]$Param3,
+                [Parameter(Position = 4)][Alias("p4")][string]$Param4,
+                [Parameter(Position = 5)][Alias("p5")][string]$Param5,
+                [Parameter(Position = 6)][Alias("p6")][string]$Param6
+            )
+            begin{
+                $commandLine = "$Param0 $Param1 $Param2 $Param3 $Param4 $Param5 $Param6".trim()
+                $tags = @(
+                    'latest'
+                    'release-candidate'
+                    'not-a-version'
+                    'initial-commit'
+                )
+            }
+            process{
+                switch -Wildcard ($commandLine) {
+                    '--version' { return 'git version 2.30.0.mock' }
+                    'tag *' {$global:LASTEXITCODE = 0; return $tags}
+                    default { throw "Unexpected git command: $commandLine" }
+                }
+            }
+        }
+
+        Set-Alias -name 'git' -Value invoke-GitCommand
+
+        $latestVer = Get-MFGitLatestVersion
+    }
+
+    It 'Should fall back to 1.0.0 when no semver tags are present' {
+        $latestVer.GetType().name | should -be 'SemanticVersion'
+        $latestVer.ToString() | should -be '1.0.0'
+        $latestVer.prereleaselabel | should -BeNullOrEmpty
+    }
+
+    AfterAll{
+        remove-alias git
+    }
+}

--- a/source/functions/Get-MFGitLatestVersion.ps1
+++ b/source/functions/Get-MFGitLatestVersion.ps1
@@ -7,10 +7,9 @@ function Get-MFGitLatestVersion
             
         .DESCRIPTION
             This function queries Git for available tags and processes them as semantic versions.
-            If no tags are found, it initializes a new version starting from `1.0.0`.
+            If no tags are found, or if no tags match semver format, it initializes a new version starting from `1.0.0`.
             If Git is unavailable or returns an error, a warning is displayed, and processing continues gracefully.
             
-        ------------
         .EXAMPLE
             Get-MFGitLatestVersion
 
@@ -36,7 +35,7 @@ function Get-MFGitLatestVersion
             Latest Tag Version: 1.2.3
             ```
         .OUTPUTS
-            [semver] - Returns a Semantec Version object
+            [semver] - Returns a Semantic Version object
             
         .NOTES
             Author: Adrian Andersson
@@ -50,7 +49,7 @@ function Get-MFGitLatestVersion
     )
     begin{
         #Return the script name when running verbose, makes it tidier
-        write-verbose "===========Executing $($MyInvocation.InvocationName)==========="
+        Write-Verbose "===========Executing $($MyInvocation.InvocationName)==========="
         #Return the sent variables when running debug
         Write-Debug "BoundParams: $($MyInvocation.BoundParameters|Out-String)"
         
@@ -67,13 +66,17 @@ function Get-MFGitLatestVersion
             $versionTags = $null
         }
         
-        write-verbose "Got VersionTags: $versionTags"
+        Write-Verbose "Got VersionTags: $versionTags"
         if($versionTags) {
-        $versions = $versionTags.ForEach{[semver]::new($_.TrimStart("v"))}
-            $latest = ($versions | Sort-Object -Descending | Select-Object -First 1)
-        Write-Verbose "Latest Tag Version: $($latest.tostring())"
-        } else {
-        Write-Verbose 'Generating new version from scratch at 1'
+            $versions = $versionTags | Where-Object { $_ -match '^v?\d+\.\d+\.\d+' } | ForEach-Object { [semver]::new($_.TrimStart('v')) }
+            if($versions) {
+                $latest = ($versions | Sort-Object -Descending | Select-Object -First 1)
+                Write-Verbose "Latest Tag Version: $($latest.tostring())"
+            }
+        }
+
+        if(-not $latest) {
+            Write-Verbose 'Generating new version from scratch at 1'
             $latest = [semver]::new(1,0,0)
         }
         return $latest


### PR DESCRIPTION
# Pull Request

## Description

Small change to workflow diagram in Readme
Added resilience to the Get-MFGitlatestVersion so that if non-semver tags are present it should not error out

## Related Issues

<!-- Link related issues | Use "Fixes #123" or "AB#456" to auto-close -->

## Quick Review Checklist

- [x] Pester Tests included targeting satisfactory code coverage (>75%)
- [x] Followed Best-Practices and implemented Script Analyzer Suggestions
- [x] Reviewed "Type of Change" section below, and considered if any additional version bumps are required
- [x] Used appropriate Git commit prefixes (For automated changelog generation)

## Release Intent

<!-- Indicate the release strategy for this PR -->

- [x] This Pull Request is part of a **PreRelease series**
- [ ] This Pull Request finalises a **Stable Release**
- [ ] No release planned for this Pull Request

## Type of Changes included in this PR

<!--  Select all that apply. Use the highest-impact change as guidance in determining version increment type -->

### 🔴 Major (Breaking)

- [ ] Breaking Change to function Output
- [ ] Mandatory Parameter added or changed
- [ ] Parameter renamed without alias Support
- [ ] Major rewrite or refactor
- [ ] Other breaking change

### 🟡 Minor (Features)

- [ ] New Function(s) added
- [ ] Non-breaking change to function output
- [ ] Parameter renamed with backwards-compatible alias
- [ ] New optional parameter
- [ ] Input validation changes
- [x] Other minor enhancements

### 🟢 Patch (Fixes & Maintenance)

- [x] Bug Fix(es)
- [ ] Stream Output Changes (Verbose, Error, etc)
- [x] Performance or style improvements
- [x] Test updates or additions
- [ ] Other patch-level change

### ⚪ Non-Release Change

- [x] Documentation update or change
- [ ] CI/CD or workflow change
- [ ] Internal tooling or developer experience
- [ ] Other non-release change

<!-- To Repository Owners:

This PR template reflects a workflow used by ModuleForge's author. It’s designed to support semantic versioning, pre-release planning, and cross-platform issue linking. 
Feel free to adapt it to your own project needs, use it as is, or create your own entirely

-->