### PR TITLE
feat: Add more ModuleForge building version  for security checks. PSM…

### DIFF
--- a/source/functions/build/Build-MFProject.Tests.ps1
+++ b/source/functions/build/Build-MFProject.Tests.ps1
@@ -223,6 +223,27 @@ describe 'Build-MFProject' {
         $privateData.PSData.IconUri | Should -Be 'https://example.com/logo.png'
     }
 
+    It 'Should record ModuleForge build provenance in the manifest PrivateData' {
+        #Flat scalar keys let a consumer verify which ModuleForge build produced the module, by comparing
+        #these SHA256 hashes against the checksums published on the ModuleForge release. They are flat rather
+        #than a nested hashtable because New-ModuleManifest stringifies nested hashtables in custom PrivateData
+        $psd = (get-childItem -path 'build' -recurse -filter '*.psd1').fullname
+        $privateData = (Import-PowerShellDataFile -Path $psd).PrivateData
+        $privateData.ModuleForgeBuildVersion | Should -Not -BeNullOrEmpty
+        #Hashes are lower-case SHA256 hex, or 'unknown' when the ModuleForge files cannot be located
+        $privateData.ModuleForgeBuildPsd1SHA256 | Should -Match '^([a-f0-9]{64}|unknown)$'
+        $privateData.ModuleForgeBuildPsm1SHA256 | Should -Match '^([a-f0-9]{64}|unknown)$'
+        $privateData.ModuleForgeBuildDate | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Should include the ModuleForge version and hashes in the psm1 header' {
+        $psm1 = (get-childItem -path 'build' -recurse -filter '*.psm1').fullname
+        $header = Get-Content -Path $psm1 -Raw
+        $header | Should -BeLike '*Module built with ModuleForge*'
+        $header | Should -BeLike '*ModuleForge psd1 SHA256:*'
+        $header | Should -BeLike '*ModuleForge psm1 SHA256:*'
+    }
+
 
 
 }
@@ -339,6 +360,29 @@ describe 'Build-MFProject with ReleaseNotes' {
     it 'Should have release notes appended to the description' {
         $manifest = Import-PowerShellDataFile (get-childItem -path 'build' -recurse -filter '*.psd1').fullname
         $manifest.Description | Should -BeLike '*Test release notes*'
+    }
+}
+
+describe 'Build-MFProject with NoBuildProvenance' {
+    beforeAll {
+        Set-Location $testPath
+        Build-MFProject -version '1.0.0-PREv005' -NoBuildProvenance
+    }
+    it 'Should not write ModuleForge build provenance to the manifest' {
+        $privateData = (Import-PowerShellDataFile (get-childItem -path 'build' -recurse -filter '*.psd1').fullname).PrivateData
+        $privateData.ModuleForgeBuildVersion | Should -BeNullOrEmpty
+        $privateData.ModuleForgeBuildPsd1SHA256 | Should -BeNullOrEmpty
+        $privateData.ModuleForgeBuildPsm1SHA256 | Should -BeNullOrEmpty
+    }
+    it 'Should keep any custom PrivateData even with provenance suppressed' {
+        #The switch only drops ModuleForge provenance, not the author's own PrivateData
+        $privateData = (Import-PowerShellDataFile (get-childItem -path 'build' -recurse -filter '*.psd1').fullname).PrivateData
+        $privateData.TestKey | Should -Be 'TestValue'
+    }
+    it 'Should not stamp the ModuleForge provenance header in the psm1' {
+        $psm1 = Get-Content -Path (get-childItem -path 'build' -recurse -filter '*.psm1').fullname -Raw
+        $psm1 | Should -Not -BeLike '*built with ModuleForge*'
+        $psm1 | Should -Not -BeLike '*ModuleForge psm1 SHA256:*'
     }
 }
 

--- a/source/functions/build/Build-MFProject.ps1
+++ b/source/functions/build/Build-MFProject.ps1
@@ -50,9 +50,14 @@ function Build-MFProject
         [string]$ReleaseNotes,
         #If set, appends the release notes to the module description in the manifest
         [Parameter()]
-        [switch]$IncludeReleaseNotesInDescription
+        [switch]$IncludeReleaseNotesInDescription,
+        #If set, omits the ModuleForge build provenance (the psm1 header marker and the ModuleForgeBuild* keys in
+        #the manifest PrivateData). Provenance is on by default - the SHA256 hashes it records match the checksums
+        #published on the ModuleForge release, so impacted builds can be traced if a vulnerability is found in the tooling
+        [Parameter()]
+        [switch]$NoBuildProvenance
 
-        
+
     )
     begin{
         #Return the script name when running verbose, makes it tidier
@@ -134,15 +139,42 @@ function Build-MFProject
             }
         }
 
-        $moduleForgeDetails = (get-module 'ModuleForge' |Sort-Object -Property Version -Descending|select-object -First 1)
-        if($moduleForgeDetails)
+        #Capture the ModuleForge version (including any prerelease label) and the SHA256 of the ModuleForge
+        #psd1/psm1 used for this build. The prerelease label lives in PrivateData.PSData.Prerelease because a
+        #manifest ModuleVersion cannot hold a SemVer prerelease tag, so get-module's .Version alone drops it.
+        #The hashes provide build provenance - they match the SHA256 checksums published on the corresponding
+        #ModuleForge GitHub release, letting a consumer verify which ModuleForge build produced this module.
+        #Suppressed entirely (header and manifest keys) when -NoBuildProvenance is set.
+        if($NoBuildProvenance)
         {
-            $mfVersion = $moduleForgeDetails.version.tostring()
+            write-verbose 'NoBuildProvenance set; skipping ModuleForge build provenance'
+            $moduleHeader = $null
         }else{
-            $mfVersion = 'unknown'
-        }
+            $moduleForgeDetails = (get-module 'ModuleForge' |Sort-Object -Property Version -Descending|select-object -First 1)
+            if($moduleForgeDetails)
+            {
+                $mfVersion = $moduleForgeDetails.version.tostring()
+                $mfPrerelease = $moduleForgeDetails.PrivateData.PSData.Prerelease
+                if($mfPrerelease)
+                {
+                    $mfVersion = "$mfVersion-$mfPrerelease"
+                }
+                #Hash the ModuleForge psd1/psm1 from the loaded module base. Guard each so a hashing failure
+                #(e.g. an unusual module layout) degrades to 'unknown' rather than failing the build.
+                $mfPsd1Path = join-path -path $moduleForgeDetails.ModuleBase -ChildPath 'ModuleForge.psd1'
+                $mfPsm1Path = join-path -path $moduleForgeDetails.ModuleBase -ChildPath 'ModuleForge.psm1'
+                $mfPsd1Hash = if(test-path $mfPsd1Path){(Get-FileHash -Path $mfPsd1Path -Algorithm SHA256).Hash.ToLower()}else{'unknown'}
+                $mfPsm1Hash = if(test-path $mfPsm1Path){(Get-FileHash -Path $mfPsm1Path -Algorithm SHA256).Hash.ToLower()}else{'unknown'}
+            }else{
+                $mfVersion = 'unknown'
+                $mfPsd1Hash = 'unknown'
+                $mfPsm1Hash = 'unknown'
+            }
 
-        $moduleHeader = "<#`nModule created by ModuleForge`n`t ModuleForge Version: $mfVersion`n`tBuildDate: $(get-date -format s)`n#>"
+            #Single timestamp shared by the psm1 header and the manifest provenance block
+            $mfBuildDate = get-date -format s
+            $moduleHeader = "<#`nModule built with ModuleForge`n`t ModuleForge Version: $mfVersion`n`tModuleForge psd1 SHA256: $mfPsd1Hash`n`tModuleForge psm1 SHA256: $mfPsm1Hash`n`tBuildDate: $mfBuildDate`n#>"
+        }
         $sourceFolder = join-path -path $ModulePath -childPath 'source'
 
         #What folders do we need to copy the files contents of
@@ -178,8 +210,15 @@ function Build-MFProject
 
         
         #Start creating the moduleFile
-        write-verbose 'Adding Header Comment'
-        $moduleHeader|out-file $moduleFile -Force
+        if($moduleHeader)
+        {
+            write-verbose 'Adding Header Comment'
+            $moduleHeader|out-file $moduleFile -Force
+        }else{
+            #No provenance header (-NoBuildProvenance); still need to initialise/overwrite the module file
+            write-verbose 'Skipping header comment; initialising empty module file'
+            $null = new-item -Path $moduleFile -ItemType File -Force
+        }
 
 
         
@@ -398,6 +437,20 @@ function Build-MFProject
             #Recast to a clean hashtable. The value comes back from Import-Clixml as a deserialized hashtable
             #which New-ModuleManifest rejects with 'PrivateData ... must be a hash table' when Tags/ProjectUri/etc are also set
             $splatManifest.PrivateData = [hashtable]$config.PrivateData
+        }elseif(!$NoBuildProvenance){
+            $splatManifest.PrivateData = @{}
+        }
+        #ModuleForge build provenance. Added as flat scalar keys (not a nested hashtable) because
+        #New-ModuleManifest stringifies a nested hashtable in custom PrivateData to 'System.Collections.Hashtable',
+        #losing the values. Scalar keys serialise natively and sit alongside the PSData block the cmdlet generates.
+        #These SHA256 hashes match the checksums published on the corresponding ModuleForge GitHub release,
+        #so a consumer can verify which ModuleForge build produced this module. Skipped when -NoBuildProvenance is set.
+        if(!$NoBuildProvenance)
+        {
+            $splatManifest.PrivateData.ModuleForgeBuildVersion    = $mfVersion
+            $splatManifest.PrivateData.ModuleForgeBuildPsd1SHA256 = $mfPsd1Hash
+            $splatManifest.PrivateData.ModuleForgeBuildPsm1SHA256 = $mfPsm1Hash
+            $splatManifest.PrivateData.ModuleForgeBuildDate       = $mfBuildDate
         }
 
         #FunctionsToExport


### PR DESCRIPTION
…1 and PSD1 are stamped on build with Build-MFProject. Can be skipped with a switch

# Pull Request

## Description

Improve ModuleForge version stamping in build

## Related Issues

<!-- Link related issues | Use "Fixes #123" or "AB#456" to auto-close -->

## Quick Review Checklist

- [x] Pester Tests included targeting satisfactory code coverage (>75%)
- [x] Followed Best-Practices and implemented Script Analyzer Suggestions
- [x] Reviewed "Type of Change" section below, and considered if any additional version bumps are required
- [x] Used appropriate Git commit prefixes (For automated changelog generation)

## Release Intent

<!-- Indicate the release strategy for this PR -->

- [ ] This Pull Request is part of a **PreRelease series**
- [ ] This Pull Request finalises a **Stable Release**
- [ ] No release planned for this Pull Request

## Type of Changes included in this PR

<!--  Select all that apply. Use the highest-impact change as guidance in determining version increment type -->

### 🔴 Major (Breaking)

- [ ] Breaking Change to function Output
- [ ] Mandatory Parameter added or changed
- [ ] Parameter renamed without alias Support
- [ ] Major rewrite or refactor
- [ ] Other breaking change

### 🟡 Minor (Features)

- [ ] New Function(s) added
- [ ] Non-breaking change to function output
- [ ] Parameter renamed with backwards-compatible alias
- [x] New optional parameter
- [ ] Input validation changes
- [x] Other minor enhancements

### 🟢 Patch (Fixes & Maintenance)

- [ ] Bug Fix(es)
- [x] Stream Output Changes (Verbose, Error, etc)
- [ ] Performance or style improvements
- [x] Test updates or additions
- [ ] Other patch-level change

### ⚪ Non-Release Change

- [ ] Documentation update or change
- [ ] CI/CD or workflow change
- [ ] Internal tooling or developer experience
- [ ] Other non-release change

<!-- To Repository Owners:

This PR template reflects a workflow used by ModuleForge's author. It’s designed to support semantic versioning, pre-release planning, and cross-platform issue linking. 
Feel free to adapt it to your own project needs, use it as is, or create your own entirely

-->